### PR TITLE
detect any directory with /test in path as test package

### DIFF
--- a/java/gazelle/private/java/java.go
+++ b/java/gazelle/private/java/java.go
@@ -21,7 +21,7 @@ func IsTestPackage(pkg string) bool {
 		}
 	}
 
-	return strings.Contains(pkg, "/test/")
+	return strings.Contains(pkg, "/test")
 }
 
 // This list was derived from a script along the lines of:


### PR DESCRIPTION
We have not very java-like structure in our monorepo:
```
├── common
│   ├── BUILD.bazel
│   ├── GrpcLogging.java
│   ├── MetadataUtil.java
│   └── test
│       └── MetadataLoggingTest.java
```
So current func IsTestPackage doesn't detect our tests as tests and we have `found MULTIPLE results in rule index` error because of the same package in test classes.
We propose the fix, so files in packages like //common/test will also fit as test packages.